### PR TITLE
Added mariadb example, image-helpgen man page, and new template.tpl

### DIFF
--- a/example/mariadb/Dockerfile
+++ b/example/mariadb/Dockerfile
@@ -1,0 +1,82 @@
+# MariaDB is a multi-user, multi-threaded SQL database server.
+# The container image provides a containerized packaging of the
+# MariaDB mysqld daemon and client application. The mysqld server
+# daemon accepts connections from clients and provides access to
+# content from MariaDB databases on behalf of the clients.
+#
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+#
+# Volumes: 
+#
+#  /var/lib/mysql/data - Datastore for MySQL 
+#
+# Environment: 
+#
+#  $MYSQL_USER - Database user name 
+#
+#  $MYSQL_PASSWORD - User's password 
+#
+#  $MYSQL_DATABASE - Name of the database to create 
+#
+#  $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account 
+
+ENV MYSQL_VERSION=10.2 \
+APP_DATA=/opt/app-root/src 
+HOME=/var/lib/mysql 
+SUMMARY="MariaDB 10.2 SQL database server" 
+DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container 
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. 
+The mysqld server daemon accepts connections from clients and provides access to content from 
+MariaDB databases on behalf of the clients."
+
+LABEL summary="MariaDB 10.2 SQL database server" \
+#     description="$DESCRIPTION" \
+      url="https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html-single/using_red_hat_software_collections_container_images/#mariadb"
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MariaDB 10.2" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102" \
+      com.redhat.component="rh-mariadb102-docker" \
+      name="rhscl/mariadb-102-rhel7" \
+      version="1" \
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-102-rhel7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
+    INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils rh-mariadb102" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/opt/rh/rh-mariadb102/root/usr \
+    ENABLED_COLLECTIONS=rh-mariadb102
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+COPY 10.2/root-common /
+COPY 10.2/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.2/root /
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+VOLUME ["/var/lib/mysql/data"]
+USER 27
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/example/mariadb/README.md
+++ b/example/mariadb/README.md
@@ -1,0 +1,23 @@
+# Example container help page for mariadb
+
+Here are the basic steps to create the help.1 and help.md files
+from the Dockerfile in this directory:
+
+Generated the help.md file from the Dockerfile with this command:
+
+```
+  image-helpgen dockerfile -dockerfile Dockerfile 
+
+```
+Manually edited the help.md file to change TODO entries to descriptions
+and add host mount points and host port numbers, then ran:
+
+```
+  image-helpgen man 
+```
+
+To check the edits in the resulting help.1 file, run:
+
+```
+   man ./help.1
+```

--- a/example/mariadb/help.1
+++ b/example/mariadb/help.1
@@ -1,0 +1,124 @@
+.TH "rhscl/mariadb-102-rhel7" "2" " Container Image Pages" "SoftwareCollections.org" "May 2018" 
+.nh
+.ad l
+
+
+.SH NAME
+.PP
+rhscl/mariadb\-102\-rhel7 \- MariaDB 10.2 SQL database server
+
+
+.SH DESCRIPTION
+.PP
+MariaDB is a multi\-user, multi\-threaded SQL database server. The container image provides a containerized packaging of the MariaDB mysqld daemon and client application. The mysqld server daemon accepts connections from clients and provides access to content from MariaDB databases on behalf of the clients.
+
+.PP
+This image must forever use UID 27 for mysql user so our volumes are safe in the future. This should \fInever\fP change, the last test is there to make sure of that.
+
+.PP
+Volumes:
+
+.PP
+/var/lib/mysql/data \- Datastore for MySQL
+
+.PP
+Environment:
+
+.PP
+$MYSQL\_USER \- Database user name
+
+.PP
+$MYSQL\_PASSWORD \- User's password
+
+.PP
+$MYSQL\_DATABASE \- Name of the database to create
+
+.PP
+$MYSQL\_ROOT\_PASSWORD (Optional) \- Password for the 'root' MySQL account
+
+
+.SH USAGE
+.PP
+docker run \-d \-e MYSQL\_USER=user \-e MYSQL\_PASSWORD=pass \-e MYSQL\_DATABASE=db \-p 3306:3306 rhscl/mariadb\-102\-rhel7
+
+
+.SH ENVIRONMENT VARIABLES
+.PP
+The image recognizes the following environment variables that you can set
+during initialization by passing \fB\fC\-e VAR=VALUE\fR to the \fB\fCdocker run\fR command.
+
+.TS
+allbox;
+l l l 
+l l l .
+\fB\fCVariable name\fR	\fB\fCDefault\fR	\fB\fCDescription\fR
+\fB\fCMYSQL\_VERSION\fR	\fB\fC10.2\fR	Current MySQL version number
+\fB\fCAPP\_DATA\fR	\fB\fC/opt/app\-root/src\fR	T{
+Data directory used by database
+T}
+T{
+\fB\fCCONTAINER\_SCRIPTS\_PATH\fR
+T}	T{
+\fB\fC/usr/share/container\-scripts/mysql\fR
+T}	Path to mysql script
+\fB\fCMYSQL\_PREFIX\fR	T{
+\fB\fC/opt/rh/rh\-mariadb102/root/usr\fR
+T}	Prefix for MySQL usr directory
+\fB\fCENABLED\_COLLECTIONS\fR	\fB\fCrh\-mariadb102\fR	Software collections name
+\fB\fCBASH\_ENV\fR	T{
+\fB\fC${CONTAINER\_SCRIPTS\_PATH}/scl\_enable\fR
+T}	T{
+Path to enable software collections
+T}
+\fB\fCENV\fR	T{
+\fB\fC${CONTAINER\_SCRIPTS\_PATH}/scl\_enable\fR
+T}	T{
+Path to enable software collections
+T}
+\fB\fCPROMPT\_COMMAND\fR	T{
+\fB\fC\&#34;. ${CONTAINER\_SCRIPTS\_PATH}/scl\_enable\&#34;\fR
+T}	Shell prompt
+.TE
+
+
+.SH SECURITY IMPLICATIONS
+.PP
+The following sections describe potential security issues related to how the container image was designed to run.
+
+.SH Ports
+.PP
+Exposed TCP (default) or UDP ports that the container listens on at runtime include the following:
+
+.TS
+allbox;
+l l l 
+l l l .
+\fB\fCPort Container\fR	\fB\fCPort Host\fR	\fB\fCDescription\fR
+3306	3306	T{
+TCP port used to access mariadb service
+T}
+.TE
+
+.SH Volumes
+.PP
+Directories that are mounted from the host system to a mount point inside the container include the following:
+
+.TS
+allbox;
+l l l 
+l l l .
+\fB\fCVolume Container\fR	\fB\fCVolume Host\fR	\fB\fCDescription\fR
+/var/lib/mysql/data	/var/lib/mysql/data	T{
+Database data directory mounted from host
+T}
+.TE
+
+.SH Daemon
+.PP
+This image is expected to be run as a daemon
+
+
+.SH SEE ALSO
+.PP
+(
+\[la]https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html-single/using_red_hat_software_collections_container_images/#mariadb\[ra])

--- a/example/mariadb/help.md
+++ b/example/mariadb/help.md
@@ -1,0 +1,76 @@
+% rhscl/mariadb-102-rhel7(2) Container Image Pages
+% SoftwareCollections.org
+% May 2018
+
+# NAME
+rhscl/mariadb-102-rhel7 - MariaDB 10.2 SQL database server
+
+# DESCRIPTION
+ MariaDB is a multi-user, multi-threaded SQL database server. The container image provides a containerized packaging of the MariaDB mysqld daemon and client application. The mysqld server daemon accepts connections from clients and provides access to content from MariaDB databases on behalf of the clients.
+
+ This image must forever use UID 27 for mysql user so our volumes are safe in the future. This should *never* change, the last test is there to make sure of that.
+
+ Volumes: 
+
+  /var/lib/mysql/data - Datastore for MySQL 
+
+ Environment: 
+
+  $MYSQL_USER - Database user name 
+
+  $MYSQL_PASSWORD - User&#39;s password 
+
+  $MYSQL_DATABASE - Name of the database to create 
+
+  $MYSQL_ROOT_PASSWORD (Optional) - Password for the &#39;root&#39; MySQL account 
+
+
+# USAGE
+docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-102-rhel7
+
+# ENVIRONMENT VARIABLES
+
+The image recognizes the following environment variables that you can set
+during initialization by passing `-e VAR=VALUE` to the `docker run` command.
+
+|     Variable name        | Default |      Description                                           |
+| :----------------------- | ------- | ---------------------------------------------------------- |
+| `MYSQL_VERSION` | `10.2`   | Current MySQL version number |
+| `APP_DATA` | `/opt/app-root/src`   | Data directory used by database |
+| `CONTAINER_SCRIPTS_PATH` | `/usr/share/container-scripts/mysql`   | Path to mysql script |
+| `MYSQL_PREFIX` | `/opt/rh/rh-mariadb102/root/usr`   | Prefix for MySQL usr directory |
+| `ENABLED_COLLECTIONS` | `rh-mariadb102`   | Software collections name |
+| `BASH_ENV` | `${CONTAINER_SCRIPTS_PATH}/scl_enable`   | Path to enable software collections |
+| `ENV` | `${CONTAINER_SCRIPTS_PATH}/scl_enable`   | Path to enable software collections |
+| `PROMPT_COMMAND` | `&#34;. ${CONTAINER_SCRIPTS_PATH}/scl_enable&#34;`   | Shell prompt |
+
+
+# SECURITY IMPLICATIONS
+The following sections describe potential security issues related to how the container image was designed to run.
+
+## Ports
+
+Exposed TCP (default) or UDP ports that the container listens on at runtime include the following:
+
+|     Port Container | Port Host  |       Description             |
+| :----------------- | -----------|-------------------------------|
+| 3306 | 3306 | TCP port used to access mariadb service |
+
+
+
+## Volumes
+
+Directories that are mounted from the host system to a mount point inside the container include the following:
+
+|     Volume Container | Volume Host  |       Description             |
+| :----------------- | -----------|-------------------------------|
+| /var/lib/mysql/data | /var/lib/mysql/data | Database data directory mounted from host |
+
+
+## Daemon
+This image is expected to be run as a daemon
+
+
+# SEE ALSO
+https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html-single/using_red_hat_software_collections_container_images/#mariadb
+

--- a/image-helpgen.1
+++ b/image-helpgen.1
@@ -1,0 +1,74 @@
+.TH "IMAGE-HELPGEN" "1" "User Commands" "Steve Milner" "May 2018" 
+.nh
+.ad l
+
+
+.SH NAME
+.PP
+image-helpgen \- Create container help pages 
+
+
+.SH DESCRIPTION
+.PP
+The image-helpgen command lets you create a container help page from either guided prompts or content from a Dockerfile. Output from image-helpgen is a help.md file (in Markdown format) and/or a help.1 file (in manpage format) that describes the container, its uses, and possible security issues.
+
+By placing the help.1 file in a container image's root directory (/help.1), it can be displayed by various container tools.
+.PP
+.SH USAGE
+.PP
+image-helpgen <command> [args]
+
+.SH OPTIONS
+.PP
+guide
+      Prompts for container image content (name, usage, etc.) and produces help.1 and help.md files.
+
+dockerfile
+      Parses a Dockerfile and generates a help page template in Markdown format (help.md).
+
+man
+      Generates container help page (help.1) in manpage format from a completed Markdown file (help.md).
+
+version
+      Shows version information and exits.
+
+.SH CONTAINER HELP PAGE
+Whether using the guide or dockerfile option, the following sections are created in the resulting help page:
+
+* NAME: The NAME line is constructed from the values of “LABEL name”  + “LABEL summary” values in the Dockerfile.
+
+* DESCRIPTION: All commented lines (#) at the beginning of the Dockerfile are used as the help file’s DESCRIPTION. Add a line with just a # to have separate paragraphs. A line not beginning with a comment character (#) ends the description.
+
+* ENVIRONMENT VARIABLES: The variable name and default setting for all lines beginning with ENV in the Dockerfile are added to the ENVIRONMENT VARIABLES table.
+
+* SECURITY IMPLICATIONS: The security implications section is made up of the following subsections:
+
+    * Ports: Port numbers on EXPOSE lines are added to the Ports table.
+    * Volumes: Directories listed on VOLUME lines are added to the Volumes table.
+    * Daemon: If “-d” is on the usage line, text notes the container runs as a daemon.
+    * Expected Capabilities: Each --cap-add on the usage line adds an entry to the capabilities table.
+
+* SEE ALSO: The value of any “LABEL url” line from the Dockerfile is added to the SEE ALSO section.
+
+* Headings and footers: The header is created from this Dockerfile information: "LABEL name="  Month/Year "LABEL name="(2) and the footer is created from: ”LABEL maintainer” Container Image Pages “LABEL name=”(2)
+
+.SH EXAMPLES
+    image-helpgen dockerfile -dockerfile Dockerfile
+            # Creates a help.md file from the Dockerfile in the current directory
+            # Descriptions need to be added manually (look for TODO lines)
+
+    image-helpgen guide
+      Image name: myownimage
+            # Creates a help.md and help.1 file from content you input from prompts
+
+    image-helpgen man
+            # Produces a help.1 file from the help.md file in the current directory
+
+.SH FILES
+/etc/image-helpgen/template.tpl
+      Template file used to create container help pages.
+
+.SH SEE ALSO
+.PP
+
+https://github.com/ashcrow/image-helpgen

--- a/template.tpl
+++ b/template.tpl
@@ -15,7 +15,7 @@
 # ENVIRONMENT VARIABLES
 
 The image recognizes the following environment variables that you can set
-during initialization be passing `-e VAR=VALUE` to the Docker run command.
+during initialization by passing `-e VAR=VALUE` to the `docker run` command.
 
 |     Variable name        | Default |      Description                                           |
 | :----------------------- | ------- | ---------------------------------------------------------- |
@@ -23,8 +23,12 @@ during initialization be passing `-e VAR=VALUE` to the Docker run command.
 {{ end }}
 
 # SECURITY IMPLICATIONS
+The following sections describe potential security issues related to how the container image was designed to run.
 
 ## Ports
+
+Exposed TCP (default) or UDP ports that the container listens on at runtime include the following:
+
 |     Port Container | Port Host  |       Description             |
 | :----------------- | -----------|-------------------------------|
 {{ range $_, $_data := .ImagePorts }}| {{ $_data.Container }} | {{ $_data.Host }} | {{ $_data.Description }} |
@@ -32,6 +36,9 @@ during initialization be passing `-e VAR=VALUE` to the Docker run command.
 
 
 ## Volumes
+
+Directories that are mounted from the host system to a mount point inside the container include the following:
+
 |     Volume Container | Volume Host  |       Description             |
 | :----------------- | -----------|-------------------------------|
 {{ range $_, $_data := .ImageVolumes }}| {{ $_data.Container }} | {{ $_data.Host }} | {{ $_data.Description }} |
@@ -40,7 +47,12 @@ during initialization be passing `-e VAR=VALUE` to the Docker run command.
 {{ if .ImageExpectedDaemon }}## Daemon
 This image is expected to be run as a daemon{{ end }}
 {{ if .ImageExpectedCaps }}
-## Expected Capabilities{{ range $_, $_cap := .ImageExpectedCaps }}
+
+## Expected Capabilities
+
+This container needs to open one or more Linux capabilities (see `man capabilities 7`) to the host computer. The following capababilities (added with the \-\-cap\-add option) are expected:
+
+{{ range $_, $_cap := .ImageExpectedCaps }}
 - {{ $_cap }}{{ end }}
 {{ end}}
 


### PR DESCRIPTION
I created a mariadb directory in the example directory and added a Dockerfile, help.1, help.md and README.md file I also added some text to the template.tpl file (to change descriptions in the generated pages), and create an image-helpgen.1 man page