### PR TITLE
Enable documenting via comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,56 @@ help.1 help.md
 ```
 $ sudo podman run --rm -v `pwd`:/data:z image-helpgen:1.0 dockerfile --dockerfile Dockerfile 
 ```
+
+## How to document
+
+### Long Description
+To create a long description for your Dockerfile start the Dockerfile with comments.
+
+*Example*
+
+```
+#This is my long description. This is a single line.
+#
+#Now this is a different line with a newline between.
+#This is the last line and by not providing another comment hash it will be the end of the long description.
+
+[...]
+```
+
+### Environment Variables (`ENV`)
+To document an environment variable:
+
+1. The `ENV` must be on it's own line with only one variable
+2. Place a comment above the `ENV` directive with your description
+
+*Example*
+```
+# Defines the version of this Dockerfile
+ENV DOCKERVERSION="1.2.3"
+```
+
+### Ports (`EXPOSE`)
+To document a port exposures:
+
+1. The `EXPOSE` must be on it's own line with only one port listed
+2. Place a comment above the `EXPOSE` line with $CONTAINERPORT->$HOSTPORT $DESCRIPTION
+
+*Example*
+```
+#8080->80 Provides access to the web server
+EXPOSE 8080
+```
+
+
+### Volumes (`VOLUME`)
+To document a volume:
+
+1. The `VOLUME` must be on it's own line with only one volume listed
+2. Place a commend above the `VOLUME` line with $CONTAINERVOLUME->$HOSTVOLUME $DESCRIPTION
+
+*Example*
+```
+#/rootfs->/ The hosts root filesystem for the container to modify
+VOLUME /rootfs
+```

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -6,7 +6,13 @@
 #on it.
 FROM registry.fedoraproject.org/fedora:rawhide
 
-ENV VERSION=0.1 RELEASE=10 ARCH=x86_64
+# Denotes the version of this dockerfile
+ENV VERSION=0.1
+# Denotes the release of this dockerfile
+ENV RELEASE=10
+# Denotes the architecture
+ENV ARCH=x86_64
+
 LABEL com.redhat.component="some-compoenent" \
       name="$FGC/some-componenet" \
       version="$VERSION" \
@@ -35,9 +41,22 @@ RUN mkdir -p /exports/hostfs/usr/local/bin/ && cp /usr/bin/etcdctl /exports/host
 
 RUN mkdir -p /exports/hostfs/etc/etcd && sed -e "/^ETCD_DATA_DIR/d" -e s"|^ETCD_NAME=|#ETCD_NAME=|" < /etc/etcd/etcd.conf > /exports/hostfs/etc/etcd/etcd.conf
 
-EXPOSE 4001 7001 2379 2380
+#4001->4001 Use for something
+EXPOSE 4001
+#7001->7001 Used for something else
+EXPOSE 7001
+#2379->2379 Used for the another thing
+EXPOSE 2379
+#2380->2380 Used for the last thing
+EXPOSE 2380
 
-VOLUME /test /something /else
+#/test->/tmp/test A test mount
+VOLUME /test
+#/something->/tmp/something Another test mount
+VOLUME /something
+#/else->/tmp/else The else test mount
+VOLUME /else
+#/another->/var/tmp/another The last test mount
 VOLUME /another
 
 CMD ["/usr/bin/etcd-env.sh", "/usr/bin/etcd"]

--- a/example/help.1
+++ b/example/help.1
@@ -1,4 +1,4 @@
-.TH "$FGC/some-componenet" "2" " Container Image Pages" "Steve Milner" "May 2018" 
+.TH "$FGC/some-componenet" "2" " Container Image Pages" "Steve Milner" "October 2018" 
 .nh
 .ad l
 
@@ -21,45 +21,63 @@ If you want to have a second paragraph then add a comment line with nothing on i
 /usr/bin/docker run \-\-cap\-add NET\_ADMIN \-d \-\-cap\-add=SYS\_ADMIN  \-p 4001:4001 \-p 7001:7001 \-p 2379:2379 \-p 2380:2380
 
 
+.SH Default Command
+.PP
+/usr/bin/etcd\-env.sh /usr/bin/etcd
+
+
 .SH ENVIRONMENT VARIABLES
 .PP
 The image recognizes the following environment variables that you can set
-during initialization be passing \fB\fC\-e VAR=VALUE\fR to the Docker run command.
+during initialization by passing \fB\fC\-e VAR=VALUE\fR to the \fB\fCdocker run\fR command.
 
 .TS
 allbox;
 l l l 
 l l l .
 \fB\fCVariable name\fR	\fB\fCDefault\fR	\fB\fCDescription\fR
-\fB\fCVERSION\fR	\fB\fC0.1\fR	TODO
-\fB\fCRELEASE\fR	\fB\fC10\fR	TODO
-\fB\fCARCH\fR	\fB\fCx86\_64\fR	TODO
+\fB\fCVERSION\fR	\fB\fC0.1\fR	T{
+Denotes the version of this dockerfile
+T}
+\fB\fCRELEASE\fR	\fB\fC10\fR	T{
+Denotes the release of this dockerfile
+T}
+\fB\fCARCH\fR	\fB\fCx86\_64\fR	Denotes the architecture
 .TE
 
 
 .SH SECURITY IMPLICATIONS
+.PP
+The following sections describe potential security issues related to how the container image was designed to run.
+
 .SH Ports
+.PP
+Exposed TCP (default) or UDP ports that the container listens on at runtime include the following:
+
 .TS
 allbox;
 l l l 
 l l l .
 \fB\fCPort Container\fR	\fB\fCPort Host\fR	\fB\fCDescription\fR
-4001	0	TODO
-7001	0	TODO
-2379	0	TODO
-2380	0	TODO
+4001	4001	Use for something
+7001	7001	Used for something else
+2379	2379	Used for the another thing
+2380	2380	Used for the last thing
 .TE
 
 .SH Volumes
+.PP
+Directories that are mounted from the host system to a mount point inside the container include the following:
+
 .TS
 allbox;
 l l l 
 l l l .
 \fB\fCVolume Container\fR	\fB\fCVolume Host\fR	\fB\fCDescription\fR
-/test	TODO	TODO
-/something	TODO	TODO
-/else	TODO	TODO
-/another	TODO	TODO
+/test	/tmp/test	A test mount
+/something	/tmp/something	Another test mount
+/else	/tmp/else	The else test mount
+/another	/var/tmp/another	The last test mount
 .TE
 
 .SH Daemon
@@ -67,6 +85,9 @@ l l l .
 This image is expected to be run as a daemon
 
 .SH Expected Capabilities
+.PP
+This container needs to open one or more Linux capabilities (see \fB\fCman capabilities 7\fR) to the host computer. The following capababilities (added with the \-\-cap\-add option) are expected:
+
 .RS
 .IP \(bu 2
 NET\_ADMIN
@@ -80,3 +101,5 @@ SYS\_ADMIN
 .PP
 
 \[la]http://example.org/asd/asd\[ra]
+
+\[la]http://example.org/sdgfsdf\[ra]

--- a/example/help.md
+++ b/example/help.md
@@ -1,6 +1,6 @@
 % $FGC/some-componenet(2) Container Image Pages
 % Steve Milner
-% May 2018
+% October 2018
 
 # NAME
 $FGC/some-componenet - A key-value store for shared configuration and service discovery.
@@ -14,46 +14,62 @@ If you want to have a second paragraph then add a comment line with nothing on i
 # USAGE
 /usr/bin/docker run --cap-add NET_ADMIN -d --cap-add=SYS_ADMIN  -p 4001:4001 -p 7001:7001 -p 2379:2379 -p 2380:2380
 
+# Default Command
+/usr/bin/etcd-env.sh /usr/bin/etcd
+
 # ENVIRONMENT VARIABLES
 
 The image recognizes the following environment variables that you can set
-during initialization be passing `-e VAR=VALUE` to the Docker run command.
+during initialization by passing `-e VAR=VALUE` to the `docker run` command.
 
 |     Variable name        | Default |      Description                                           |
 | :----------------------- | ------- | ---------------------------------------------------------- |
-| `VERSION` | `0.1`   | TODO |
-| `RELEASE` | `10`   | TODO |
-| `ARCH` | `x86_64`   | TODO |
+| ` VERSION` | `0.1`   |  Denotes the version of this dockerfile |
+| ` RELEASE` | `10`   |  Denotes the release of this dockerfile |
+| ` ARCH` | `x86_64`   |  Denotes the architecture |
 
 
 # SECURITY IMPLICATIONS
+The following sections describe potential security issues related to how the container image was designed to run.
 
 ## Ports
+
+Exposed TCP (default) or UDP ports that the container listens on at runtime include the following:
+
 |     Port Container | Port Host  |       Description             |
 | :----------------- | -----------|-------------------------------|
-| 4001 | 0 | TODO |
-| 7001 | 0 | TODO |
-| 2379 | 0 | TODO |
-| 2380 | 0 | TODO |
-
+| 4001 | 4001 | Use for something |
+| 7001 | 7001 | Used for something else |
+| 2379 | 2379 | Used for the another thing |
+| 2380 | 2380 | Used for the last thing |
 
 
 ## Volumes
+
+Directories that are mounted from the host system to a mount point inside the container include the following:
+
 |     Volume Container | Volume Host  |       Description             |
 | :----------------- | -----------|-------------------------------|
-| /test | TODO | TODO |
-| /something | TODO | TODO |
-| /else | TODO | TODO |
-| /another | TODO | TODO |
+| /test | /tmp/test | A test mount |
+| /something | /tmp/something | Another test mount |
+| /else | /tmp/else | The else test mount |
+| /another | /var/tmp/another | The last test mount |
 
 
 ## Daemon
 This image is expected to be run as a daemon
 
+
 ## Expected Capabilities
+
+This container needs to open one or more Linux capabilities (see `man capabilities 7`) to the host computer. The following capababilities (added with the \-\-cap\-add option) are expected:
+
+
 - NET_ADMIN
 - SYS_ADMIN
 
 
 # SEE ALSO
+
 http://example.org/asd/asd
+http://example.org/sdgfsdf


### PR DESCRIPTION
This PR provides a way to document `ENV`, `VOLUME`, and `EXPOSE` closing the loop and allowing every expected portion of the file to generate documentation.

Resolves #3.